### PR TITLE
Add Proxmox howto

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,7 @@ After the checks for the URL are finished and correct you need to login with you
 And if everythink is ok, you're logged in 🎉
 
 Now you receive background notifications when Gotify receives a message.
+
+## 🔧 Proxmox Notifications with Gotify and iGotify
+A quick how to guid on using Proxmox 8.1 Notifications with Gotify and iGotify [Proxmox Notifications](https://homelab.casaursus.net/ghost/#/editor/post/659c1057b01bc700015c13e9)
+

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ And if everythink is ok, you're logged in 🎉
 
 Now you receive background notifications when Gotify receives a message.
 
+
 ## 🔧 Proxmox Notifications with Gotify and iGotify
-A quick how to guid on using Proxmox 8.1 Notifications with Gotify and iGotify [Proxmox Notifications](https://homelab.casaursus.net/ghost/#/editor/post/659c1057b01bc700015c13e9)
+A quick howto guid on using Proxmox 8.1 Notifications with Gotify and iGotify [Proxmox Notifications](https://homelab.casaursus.net/ghost/#/editor/post/659c1057b01bc700015c13e9)
 


### PR DESCRIPTION
How to use Gotify and iGotify for Proxmox Notifications for users with iPhones. As Gotify only supports Android this way also iPhone users can get alarms on their phones,